### PR TITLE
Updating deployment role for 1.21

### DIFF
--- a/cloudformation/panther-deployment-role.yml
+++ b/cloudformation/panther-deployment-role.yml
@@ -72,7 +72,7 @@ Resources:
               - application-autoscaling:DescribeScalableTargets
               - application-autoscaling:PutScalingPolicy
               - application-autoscaling:RegisterScalableTarget
-              - appsync:*
+              - appsync:Delete* # can be removed in 1.22, after all AppSync infra is fully removed from existing deployments
               - athena:*
               - cloudformation:Describe*
               - cloudformation:List*
@@ -140,6 +140,7 @@ Resources:
               - elasticfilesystem:DescribeLifecycleConfiguration
               - elasticfilesystem:DescribeMountTargets
               - elasticfilesystem:DescribeMountTargetSecurityGroups
+              - elasticfilesystem:ModifyMountTargetSecurityGroups
               - elasticfilesystem:PutLifecycleConfiguration
               - elasticfilesystem:PutFileSystemPolicy
               - elasticfilesystem:ListTagsForResource
@@ -150,9 +151,6 @@ Resources:
               - ecr:GetAuthorizationToken
               - ecs:*
               - events:*
-              - firehose:DescribeDeliveryStream
-              - firehose:CreateDeliveryStream
-              - firehose:DeleteDeliveryStream
               - firehose:ListDeliveryStreams
               - glue:*
               - guardduty:CreatePublishingDestination
@@ -183,34 +181,35 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/panther*
               - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stackset/panther*
-          - Effect: Allow # for ddb athena connector
-            Action: cloudformation:*
-            Resource: !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
-          - Effect: Allow # for ddb athena connector
-            Action: serverlessrepo:*
-            Resource: !Sub arn:${AWS::Partition}:serverlessrepo:*:*:applications/*
-          - Effect: Allow # for ddb athena connector
+              - !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
+          - Effect: Allow
             Action:
-              - lambda:GetFunction
-              - lambda:CreateFunction
-            Resource: !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:ddb
-          - Effect: Allow # for ddb athena connector
-            Action: s3:GetObject
-            Resource: !Sub arn:${AWS::Partition}:s3:::awsserverlessrepo-changesets-*
-          - Effect: Allow
-            Action: dynamodb:*
+              # IMPORTANT: does *not* include access to table items
+              - dynamodb:CreateTable
+              - dynamodb:DeleteTable
+              - dynamodb:Describe*
+              - dynamodb:TagResource
+              - dynamodb:UntagResource
+              - dynamodb:UpdateContinuousBackups
+              - dynamodb:UpdateTable
+              - dynamodb:UpdateTimeToLive
             Resource: !Sub arn:${AWS::Partition}:dynamodb:*:${AWS::AccountId}:table/panther-*
-          - Effect: Allow
-            Action: ecr:*
-            Resource: !Sub arn:${AWS::Partition}:ecr:*:${AWS::AccountId}:repository/panther-*
-          - Effect: Allow
-            Action: execute-api:Invoke
-            Resource: !Sub arn:${AWS::Partition}:execute-api:*:${AWS::AccountId}:*
           - Effect: Allow
             Action: firehose:*
             Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/panther-*
           - Effect: Allow
-            Action: iam:*
+            Action:
+              - iam:AttachRolePolicy
+              - iam:CreateRole
+              - iam:DeleteRole
+              - iam:DeleteRolePolicy
+              - iam:DetachRolePolicy
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:PassRole
+              - iam:PutRolePolicy
+              - iam:UpdateRole
+              - iam:*ServerCertificate
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/AWSServiceRole*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*
@@ -218,31 +217,89 @@ Resources:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/Panther*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:server-certificate/panther/*
           - Effect: Allow
-            Action: kms:*
+            Action:
+              - kms:CreateAlias
+              - kms:Decrypt # required for KMS-encrypted S3 deployment assets (e.g. AWS::Lambda::LayerVersion)
+              - kms:DeleteAlias
+              - kms:DescribeKey
+              - kms:DisableKeyRotation
+              - kms:EnableKeyRotation
+              - kms:GetKeyPolicy
+              - kms:GetKeyRotationStatus
+              - kms:ListResourceTags
+              - kms:PutKeyPolicy
+              - kms:ScheduleKeyDeletion
+              - kms:TagResource
+              - kms:UntagResource
+              - kms:UpdateAlias
+              - kms:UpdateKeyDescription
             Resource:
               - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:alias/panther-*
-              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:key/*
+              - !Sub arn:${AWS::Partition}:kms:*:${AWS::AccountId}:key/* # key ID is not known in advance
           - Effect: Allow
-            Action: lambda:*
+            Action:
+              # IMPORTANT: does *not* include lambda:InvokeFunction
+              - lambda:AddLayerVersionPermission
+              - lambda:AddPermission
+              - lambda:CreateFunction
+              - lambda:Delete*
+              - lambda:Get*
+              - lambda:PublishLayerVersion
+              - lambda:Put*
+              - lambda:RemoveLayerVersionPermission
+              - lambda:RemovePermission
+              - lambda:TagResource
+              - lambda:UntagResource
+              - lambda:Update*
             Resource:
-              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:event-source-mapping:*
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:panther-*
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:layer:panther-*
-
-              # Panther v1.14 unintentionally introduced a Lambda function named "ddb."
-              # v1.15 renamed the function so it has the conventional "panther-" prefix.
-              #
-              # The deployment role needs to be able to delete the "ddb" function
-              # until all accounts have migrated to v1.15+. Otherwise, the migration will fail.
-              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:ddb
           - Effect: Allow
-            Action: s3:*
+            Action: lambda:InvokeFunction
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:panther-cfn-custom-resources
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:panther-pip-layer-builder
+          - Effect: Allow
+            Action:
+              # IMPORTANT: does *not* include s3:GetObject
+              - s3:CreateBucket
+              - s3:DeleteBucket*
+              - s3:GetBucket*
+              - s3:Get*Configuration
+              - s3:PutBucket*
+              - s3:Put*Configuration
             Resource: !Sub arn:${AWS::Partition}:s3:::panther-*
           - Effect: Allow
-            Action: sns:*
+            Action: s3:GetObject
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::panther-bootstrap-*analysisversions-*/layers/* # for AWS::Lambda::LayerVersion
+              # Release assets (Lambda binaries)
+              - !Sub arn:${AWS::Partition}:s3:::panther-dev-sourcebucket-*
+              - !Sub arn:${AWS::Partition}:s3:::panther-enterprise-*
+          - Effect: Allow
+            Action:
+              - sns:AddPermission
+              - sns:CreateTopic
+              - sns:DeleteTopic
+              - sns:GetTopicAttributes
+              - sns:RemovePermission
+              - sns:SetTopicAttributes
+              - sns:Subscribe
+              - sns:TagResource
+              - sns:Unsubscribe
+              - sns:UntagResource
             Resource: !Sub arn:${AWS::Partition}:sns:*:${AWS::AccountId}:panther-*
           - Effect: Allow
-            Action: sqs:*
+            Action:
+              # IMPORTANT: does *not* include sqs:ReceiveMessage
+              - sqs:AddPermission
+              - sqs:CreateQueue
+              - sqs:DeleteQueue
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+              - sqs:SetQueueAttributes
+              - sqs:TagQueue
+              - sqs:UntagQueue
             Resource: !Sub arn:${AWS::Partition}:sqs:*:${AWS::AccountId}:panther-*
           - Effect: Allow
             Action: states:*

--- a/cloudformation/panther-deployment-role.yml
+++ b/cloudformation/panther-deployment-role.yml
@@ -72,7 +72,7 @@ Resources:
               - application-autoscaling:DescribeScalableTargets
               - application-autoscaling:PutScalingPolicy
               - application-autoscaling:RegisterScalableTarget
-              - appsync:Delete* # can be removed in 1.22, after all AppSync infra is fully removed from existing deployments
+              - appsync:* # can be removed in 1.22, after all AppSync infra is fully removed from existing deployments
               - athena:*
               - cloudformation:Describe*
               - cloudformation:List*
@@ -182,6 +182,12 @@ Resources:
               - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/panther*
               - !Sub arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stackset/panther*
               - !Sub arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31
+          - Effect: Allow # for ddb athena connector - can be removed once all deployments are 1.21+
+            Action: serverlessrepo:*
+            Resource: !Sub arn:${AWS::Partition}:serverlessrepo:*:*:applications/*
+          - Effect: Allow # for ddb athena connector - can be removed once all deployments are 1.21+
+            Action: s3:GetObject
+            Resource: !Sub arn:${AWS::Partition}:s3:::awsserverlessrepo-changesets-*
           - Effect: Allow
             Action:
               # IMPORTANT: does *not* include access to table items
@@ -208,8 +214,11 @@ Resources:
               - iam:GetRolePolicy
               - iam:PassRole
               - iam:PutRolePolicy
+              - iam:UpdateAssumeRolePolicy
               - iam:UpdateRole
+              - iam:UpdateRoleDescription
               - iam:*ServerCertificate
+              - iam:CreateServiceLinkedRole
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/AWSServiceRole*
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*
@@ -252,6 +261,7 @@ Resources:
               - lambda:UntagResource
               - lambda:Update*
             Resource:
+              - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:event-source-mapping:*
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:panther-*
               - !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:layer:panther-*
           - Effect: Allow

--- a/terraform/panther_deployment_role/main.tf
+++ b/terraform/panther_deployment_role/main.tf
@@ -59,7 +59,7 @@ resource "aws_iam_policy" "deployment" {
         "application-autoscaling:DescribeScalableTargets",
         "application-autoscaling:PutScalingPolicy",
         "application-autoscaling:RegisterScalableTarget",
-        "appsync:Delete*",
+        "appsync:*",
         "athena:*",
         "cloudformation:Describe*",
         "cloudformation:List*",
@@ -179,6 +179,16 @@ resource "aws_iam_policy" "deployment" {
       ]
     },
     {
+      "Action": "serverlessrepo:*",
+      "Effect": "Allow",
+      "Resource": "arn:${var.aws_partition}:serverlessrepo:*:*:applications/*"
+    },
+    {
+      "Action": "s3:GetObject",
+      "Effect": "Allow",
+      "Resource": "arn:${var.aws_partition}:s3:::awsserverlessrepo-changesets-*"
+    },
+    {
       "Action": [
         "dynamodb:CreateTable",
         "dynamodb:DeleteTable",
@@ -208,8 +218,11 @@ resource "aws_iam_policy" "deployment" {
         "iam:GetRolePolicy",
         "iam:PassRole",
         "iam:PutRolePolicy",
+        "iam:UpdateAssumeRolePolicy",
         "iam:UpdateRole",
-        "iam:*ServerCertificate"
+        "iam:UpdateRoleDescription",
+        "iam:*ServerCertificate",
+        "iam:CreateServiceLinkedRole"
       ],
       "Effect": "Allow",
       "Resource": [
@@ -261,6 +274,7 @@ resource "aws_iam_policy" "deployment" {
       ],
       "Effect": "Allow",
       "Resource": [
+        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:event-source-mapping:*",
         "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:panther-*",
         "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:layer:panther-*"
       ]

--- a/terraform/panther_deployment_role/main.tf
+++ b/terraform/panther_deployment_role/main.tf
@@ -21,7 +21,7 @@ resource "aws_iam_role" "deployment" {
         }
         Action : "sts:AssumeRole",
         Condition : {
-          Bool : { "aws:SecureTransport" : "true" }
+          Bool : { "aws:SecureTransport" : true }
         }
       },
       {
@@ -31,7 +31,7 @@ resource "aws_iam_role" "deployment" {
         }
         Action : "sts:AssumeRole",
         Condition : {
-          Bool : { "aws:SecureTransport" : "true" }
+          Bool : { "aws:SecureTransport" : true }
         }
       },
     ]
@@ -59,7 +59,7 @@ resource "aws_iam_policy" "deployment" {
         "application-autoscaling:DescribeScalableTargets",
         "application-autoscaling:PutScalingPolicy",
         "application-autoscaling:RegisterScalableTarget",
-        "appsync:*",
+        "appsync:Delete*",
         "athena:*",
         "cloudformation:Describe*",
         "cloudformation:List*",
@@ -127,6 +127,7 @@ resource "aws_iam_policy" "deployment" {
         "elasticfilesystem:DescribeLifecycleConfiguration",
         "elasticfilesystem:DescribeMountTargets",
         "elasticfilesystem:DescribeMountTargetSecurityGroups",
+        "elasticfilesystem:ModifyMountTargetSecurityGroups",
         "elasticfilesystem:PutLifecycleConfiguration",
         "elasticfilesystem:PutFileSystemPolicy",
         "elasticfilesystem:ListTagsForResource",
@@ -137,9 +138,6 @@ resource "aws_iam_policy" "deployment" {
         "ecr:GetAuthorizationToken",
         "ecs:*",
         "events:*",
-        "firehose:DescribeDeliveryStream",
-        "firehose:CreateDeliveryStream",
-        "firehose:DeleteDeliveryStream",
         "firehose:ListDeliveryStreams",
         "glue:*",
         "guardduty:CreatePublishingDestination",
@@ -176,46 +174,23 @@ resource "aws_iam_policy" "deployment" {
       "Effect": "Allow",
       "Resource": [
         "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stack/panther*",
-        "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stackset/panther*"
+        "arn:${var.aws_partition}:cloudformation:*:${var.aws_account_id}:stackset/panther*",
+        "arn:${var.aws_partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
       ]
     },
     {
-      "Action": "cloudformation:*",
-      "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
-    },
-    {
-      "Action": "serverlessrepo:*",
-      "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:serverlessrepo:*:*:applications/*"
-    },
-    {
       "Action": [
-        "lambda:GetFunction",
-        "lambda:CreateFunction"
+        "dynamodb:CreateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:Describe*",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:UpdateTable",
+        "dynamodb:UpdateTimeToLive"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:ddb"
-    },
-    {
-      "Action": "s3:GetObject",
-      "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:s3:::awsserverlessrepo-changesets-*"
-    },
-    {
-      "Action": "dynamodb:*",
-      "Effect": "Allow",
       "Resource": "arn:${var.aws_partition}:dynamodb:*:${var.aws_account_id}:table/panther-*"
-    },
-    {
-      "Action": "ecr:*",
-      "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:ecr:*:${var.aws_account_id}:repository/panther-*"
-    },
-    {
-      "Action": "execute-api:Invoke",
-      "Effect": "Allow",
-      "Resource": "arn:${var.aws_partition}:execute-api:*:${var.aws_account_id}:*"
     },
     {
       "Action": "firehose:*",
@@ -223,7 +198,19 @@ resource "aws_iam_policy" "deployment" {
       "Resource": "arn:${var.aws_partition}:firehose:*:${var.aws_account_id}:deliverystream/panther-*"
     },
     {
-      "Action": "iam:*",
+      "Action": [
+        "iam:AttachRolePolicy",
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:DeleteRolePolicy",
+        "iam:DetachRolePolicy",
+        "iam:GetRole",
+        "iam:GetRolePolicy",
+        "iam:PassRole",
+        "iam:PutRolePolicy",
+        "iam:UpdateRole",
+        "iam:*ServerCertificate"
+      ],
       "Effect": "Allow",
       "Resource": [
         "arn:${var.aws_partition}:iam::${var.aws_account_id}:role/AWSServiceRole*",
@@ -234,7 +221,23 @@ resource "aws_iam_policy" "deployment" {
       ]
     },
     {
-      "Action": "kms:*",
+      "Action": [
+        "kms:CreateAlias",
+        "kms:Decrypt",
+        "kms:DeleteAlias",
+        "kms:DescribeKey",
+        "kms:DisableKeyRotation",
+        "kms:EnableKeyRotation",
+        "kms:GetKeyPolicy",
+        "kms:GetKeyRotationStatus",
+        "kms:ListResourceTags",
+        "kms:PutKeyPolicy",
+        "kms:ScheduleKeyDeletion",
+        "kms:TagResource",
+        "kms:UntagResource",
+        "kms:UpdateAlias",
+        "kms:UpdateKeyDescription"
+      ],
       "Effect": "Allow",
       "Resource": [
         "arn:${var.aws_partition}:kms:*:${var.aws_account_id}:alias/panther-*",
@@ -242,27 +245,82 @@ resource "aws_iam_policy" "deployment" {
       ]
     },
     {
-      "Action": "lambda:*",
+      "Action": [
+        "lambda:AddLayerVersionPermission",
+        "lambda:AddPermission",
+        "lambda:CreateFunction",
+        "lambda:Delete*",
+        "lambda:Get*",
+        "lambda:PublishLayerVersion",
+        "lambda:Put*",
+        "lambda:RemoveLayerVersionPermission",
+        "lambda:RemovePermission",
+        "lambda:TagResource",
+        "lambda:UntagResource",
+        "lambda:Update*"
+      ],
       "Effect": "Allow",
       "Resource": [
-        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:event-source-mapping:*",
         "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:panther-*",
-        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:layer:panther-*",
-        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:ddb"
+        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:layer:panther-*"
       ]
     },
     {
-      "Action": "s3:*",
+      "Action": "lambda:InvokeFunction",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:panther-cfn-custom-resources",
+        "arn:${var.aws_partition}:lambda:*:${var.aws_account_id}:function:panther-pip-layer-builder"
+      ]
+    },
+    {
+      "Action": [
+        "s3:CreateBucket",
+        "s3:DeleteBucket*",
+        "s3:GetBucket*",
+        "s3:Get*Configuration",
+        "s3:PutBucket*",
+        "s3:Put*Configuration"
+      ],
       "Effect": "Allow",
       "Resource": "arn:${var.aws_partition}:s3:::panther-*"
     },
     {
-      "Action": "sns:*",
+      "Action": "s3:GetObject",
+      "Effect": "Allow",
+      "Resource": [
+        "arn:${var.aws_partition}:s3:::panther-bootstrap-*analysisversions-*/layers/*",
+        "arn:${var.aws_partition}:s3:::panther-dev-sourcebucket-*",
+        "arn:${var.aws_partition}:s3:::panther-enterprise-*"
+      ]
+    },
+    {
+      "Action": [
+        "sns:AddPermission",
+        "sns:CreateTopic",
+        "sns:DeleteTopic",
+        "sns:GetTopicAttributes",
+        "sns:RemovePermission",
+        "sns:SetTopicAttributes",
+        "sns:Subscribe",
+        "sns:TagResource",
+        "sns:Unsubscribe",
+        "sns:UntagResource"
+      ],
       "Effect": "Allow",
       "Resource": "arn:${var.aws_partition}:sns:*:${var.aws_account_id}:panther-*"
     },
     {
-      "Action": "sqs:*",
+      "Action": [
+        "sqs:AddPermission",
+        "sqs:CreateQueue",
+        "sqs:DeleteQueue",
+        "sqs:GetQueueAttributes",
+        "sqs:GetQueueUrl",
+        "sqs:SetQueueAttributes",
+        "sqs:TagQueue",
+        "sqs:UntagQueue"
+      ],
       "Effect": "Allow",
       "Resource": "arn:${var.aws_partition}:sqs:*:${var.aws_account_id}:panther-*"
     },


### PR DESCRIPTION
## Background
Copying internal changes we made to the deployment role to reduce its scope.

## Changes
- Reduced scope of permissions for DynamoDB, ECR, S3, SNS, SQS, Lambda, KMS, and IAM

## Testing
1.21.0-RC root-stack deployment with this role
