### PR TITLE
Fix cloudformation publishing for latest version

### DIFF
--- a/cloudformation/Makefile
+++ b/cloudformation/Makefile
@@ -9,5 +9,5 @@ upload-all:
 upload-single:
 	version=`cat ../../../VERSION | xargs`; \
 	templateDisplayName=`echo $(template) | cut -d'.' -f1`; \
-	aws s3 cp $(template) s3://$(bucket)/$$templateDisplayName/v$$version/template.yml --acl public-read;
+	aws s3 cp $(template) s3://$(bucket)/$$templateDisplayName/v$$version/template.yml --acl public-read; \
 	aws s3 cp $(template) s3://$(bucket)/$$templateDisplayName/latest/template.yml --acl public-read;


### PR DESCRIPTION
## Background
Copying internal changes to fix publishing for the latest version

## Changes
- Update make file to include all commands on a single line

## Testing
Before:
```
$ make upload-single template=foo
version=`cat ../../../VERSION | xargs`; \
	templateDisplayName=`echo foo | cut -d'.' -f1`; \
	echo aws s3 cp foo s3://panther-public-cloudformation-templates/$templateDisplayName/v$version/template.yml --acl public-read;
aws s3 cp foo s3://panther-public-cloudformation-templates/foo/v1.21.0-RC/template.yml --acl public-read
echo aws s3 cp foo s3://panther-public-cloudformation-templates/$templateDisplayName/latest/template.yml --acl public-read;
aws s3 cp foo s3://panther-public-cloudformation-templates//latest/template.yml --acl public-read
```

After:
```
$ make upload-single template=foo
version=`cat ../../../VERSION | xargs`; \
	templateDisplayName=`echo foo | cut -d'.' -f1`; \
	echo aws s3 cp foo s3://panther-public-cloudformation-templates/$templateDisplayName/v$version/template.yml --acl public-read; \
	echo aws s3 cp foo s3://panther-public-cloudformation-templates/$templateDisplayName/latest/template.yml --acl public-read;
aws s3 cp foo s3://panther-public-cloudformation-templates/foo/v1.21.0-RC/template.yml --acl public-read
aws s3 cp foo s3://panther-public-cloudformation-templates/foo/latest/template.yml --acl public-read
```
