### PR TITLE
Add 'cloudtrail:GetTrail' permission to 'AuditRole' to fix permission issue

### DIFF
--- a/cloudformation/panther-cloudsec-iam.yml
+++ b/cloudformation/panther-cloudsec-iam.yml
@@ -143,6 +143,14 @@ Resources:
                   - eks:DescribeFargateProfile
                   - eks:DescribeNodegroup
                 Resource: '*'
+        - PolicyName: CloudTrailRead
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudtrail:GetTrail
+                Resource: '*'
       Tags:
         - Key: Application
           Value: Panther

--- a/terraform/panther_cloudsec_iam/main.tf
+++ b/terraform/panther_cloudsec_iam/main.tf
@@ -133,6 +133,24 @@ resource "aws_iam_role_policy" "panther_get_tags" {
   })
 }
 
+resource "aws_iam_role_policy" "panther_cloutrail_read" {
+  count = var.include_audit_role ? 1 : 0
+  name  = "CloudTrailRead"
+  role  = aws_iam_role.panther_audit[0].id
+
+  policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect : "Allow",
+        Action : [
+          "cloudtrail:GetTrail"
+        ],
+        Resource : "*"
+      }
+    ]
+  })
+}
 
 ###############################################################
 # CloudFormation StackSet Execution Role


### PR DESCRIPTION
## Background

You may not want to merge these change as-is. I just wanted to let you know that it fixes an issue in our Panther Enterprise environment where multiple AWS satellite accounts showed up in an unhealthy state. When updating the configuration of these AWS accounts in the 'Cloud Accounts' section, we would get the following error:

> Something didn't go as planned
>
> Lambda error returned: panther-source-api: Source [account name] did not pass configuration check because:

That was the full error message (I checked the browser's Developer Tools/Console).

Then I went looking through the CloudTrail event history, based on the Panther role, and found the following error:

> User: arn:aws:sts::1234567890:assumed-role/PantherAuditRole-us-east-1/1234567890 is not authorized to perform: cloudtrail:GetTrail on resource: arn:aws:cloudtrail:us-east-1:1234567890:trail/CloudTrail-Foobar because no identity-based policy allows the cloudtrail:GetTrail action

After adding the `cloudtrail:GetTrail` permission, the accounts became healthy again. This appears to be one of the `cloudrail:` read permissions that is not already included in the AWS-managed 'SecurityAuditor' role.

## Changes

- Adds missing `cloudtrail:GetTrail` permission to Panther's AuditRole

## Testing

- Already deployed to all our satellite AWS accounts

Let me know if you have any questions. Also feel free to ping me in the shared Slack channel (`#ext-framer-panther`).

We are running Panther v1.24.9 (`6a310cec1`) in us-east-1.