### PR TITLE
updates the topic subscription to use the sns_topic_name variable

### DIFF
--- a/terraform/panther_log_processing_notifications/panther_sns_topic_subscription.tf
+++ b/terraform/panther_log_processing_notifications/panther_sns_topic_subscription.tf
@@ -21,7 +21,7 @@ resource "aws_sns_topic_subscription" "panther_log_processing" {
   endpoint             = "arn:${var.aws_partition}:sqs:${var.panther_region}:${var.master_account_id}:panther-input-data-notifications-queue"
   protocol             = "sqs"
   raw_message_delivery = false
-  topic_arn            = "arn:${var.aws_partition}:sns:${var.satellite_account_region}:${each.key}:panther-notifications-topic"
+  topic_arn            = "arn:${var.aws_partition}:sns:${var.satellite_account_region}:${each.key}:${var.sns_topic_name}"
 }
 
 variable "satellite_accounts" {


### PR DESCRIPTION
## Background
Hardcoded value won't match if variable value is updated.
## Changes
Updates topic_arn to use the same value as the topic is using at creation: https://github.com/panther-labs/panther-auxiliary/blob/main/terraform/panther_log_processing_notifications/main.tf#L17
## Testing
Made changes in local fork where the variable value had been updated:

![Screen Shot 2022-05-17 at 4 01 57 PM](https://user-images.githubusercontent.com/52933995/168926049-a685fec8-cf3a-4c8f-ae8c-49a3f35d8801.png)

Ran Terraform and observed plan output was set as expected:
```
  # aws_sns_topic_subscription.panther_log_processing will be created
  + resource "aws_sns_topic_subscription" "panther_log_processing" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + confirmation_was_authenticated  = (known after apply)
      + endpoint                        = "arn:aws:sqs:us-west-2:028966251467:panther-input-data-notifications-queue"
      + endpoint_auto_confirms          = false
      + id                              = (known after apply)
      + owner_id                        = (known after apply)
      + pending_confirmation            = (known after apply)
      + protocol                        = "sqs"
      + raw_message_delivery            = false
      + topic_arn                       = "arn:aws:sns:us-west-2:account_id:panther-notifications-topic-fq"
    }
    ```
