### PR TITLE
Use harden-runner Action for all Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,16 @@
 on:
   push
 
+permissions:
+  contents: read  
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit 
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,16 @@ jobs:
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
         with:
-          egress-policy: audit 
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            releases.hashicorp.com:443
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Setup Python


### PR DESCRIPTION
### Background

Relates to EPD-368

This PR adds StepSecurity's `harden-runners` Action to all of our Workflows. 

We'll run egress blocks for Workflows that can be validated within a PR and audits for the other Workflows. Once the latter run at least once, we can implement the recommendations in a follow-up PR.

### Changes

- Adds the `harden-runner` Action to all Workflows

### Testing

- Checks pass as expected