### PR TITLE
Use full Action SHAs rather than versioned releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  # Update the GitHub actions used in our CI/CD workflow
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "@panther-labs/admin"
+    assignees:
+      - "@panther-labs/admin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,19 +21,19 @@ jobs:
             pypi.org:443
             releases.hashicorp.com:443
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Setup Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:
           python-version: 3.10.6
       - name: Install cfn-lint
         run: pip install cfn-lint
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2.0.3
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8
         with:
           terraform_version: 1.3.4
       - name: Setup tflint
-        uses: terraform-linters/setup-tflint@v2.0.1
+        uses: terraform-linters/setup-tflint@19a52fbac37dacb22a09518e4ef6ee234f2d4987
       - name: Run terraform fmt
         run: terraform fmt -check -recursive ./terraform
       - name: Run tflint


### PR DESCRIPTION
### Background

Relates to: EPD-370

Pinning Action versions to the full SHA rather than the version is a best practice from a supply chain security perspective. Dependabot will handle any updates for us.

### Changes

* Moves all Actions to their latest respective commit SHA

### Testing

* Checks still pass as expected