### PR TITLE
ignore E3030 in cfn-lint like panther enterprise does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
-on:
-  push
+on: push
 
 permissions:
-  contents: read  
+  contents: read
 
 jobs:
   validate:
@@ -27,7 +26,7 @@ jobs:
         with:
           python-version: 3.10.6
       - name: Install cfn-lint
-        run: pip install cfn-lint
+        run: pip install cfn-lint==0.85.1
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8
         with:
@@ -42,4 +41,4 @@ jobs:
           tflint --recursive
           popd
       - name: Run cfn-lint
-        run: cfn-lint -i W3045 -- cloudformation/*.yml
+        run: cfn-lint -i W3045,E3030 -- cloudformation/*.yml


### PR DESCRIPTION
## Background

Panther Enterprise ignores this error [here](https://github.com/panther-labs/panther-enterprise/blob/3a29274a97d2fb0636a6ff42195bc814882167ec/.github/workflows/infra.yml#L12). In [this](https://github.com/panther-labs/panther-auxiliary/pull/126) sync PR, CI was failing because this error was not being ignored. To get those changes through, we need to ignore it here too. 

## Changes
- Ignores E3030 in cfn-lint
- Pins version of cfn-lint to 0.85.1 to [match](https://github.com/panther-labs/panther-enterprise/blob/3a29274a97d2fb0636a6ff42195bc814882167ec/.github/workflows/infra.yml#L60) PE

## Testing
- Merged this branch into the sync branch and it now passes CI
