### PR TITLE
refactor: retry readiness check S3 bucket creation with default config

### DIFF
--- a/serverless/panther-preflight-tools/readiness-check/src/s3_select_check.py
+++ b/serverless/panther-preflight-tools/readiness-check/src/s3_select_check.py
@@ -76,9 +76,16 @@ class S3SelectEnabledCheck:
         return is_enabled
 
     def _setup_bucket(self):
-        self.log.info(f'setting up test s3 bucket ({self.test_bucket_name})')
-        self.s3.create_bucket(Bucket=self.test_bucket_name, CreateBucketConfiguration={
-                              'LocationConstraint': self.test_bucket_region})
+        self.log.info(f'setting up test s3 bucket ({self.test_bucket_name}) with LocationConstraint ({self.test_bucket_region})')
+        try:
+            self.s3.create_bucket(Bucket=self.test_bucket_name, CreateBucketConfiguration={
+                'LocationConstraint': self.test_bucket_region})
+            self.log.info(f'test s3 bucket ({self.test_bucket_name}) created')
+        except Exception as e:
+            self.log.info(f'failed to create test s3 bucket ({self.test_bucket_name}) with LocationConstraint ({self.test_bucket_region}) - exception: {e} - retrying without LocationConstraint, please request access to S3Select')
+            self.s3.create_bucket(Bucket=self.test_bucket_name)
+            self.log.info(f'test s3 bucket ({self.test_bucket_name}) created without LocationConstraint')
+
 
     def _cleanup_bucket(self):
         self.log.info(f'cleaning up test s3 bucket ({self.test_bucket_name})')


### PR DESCRIPTION
## Background
- We are getting inconsistent failures, we want to identify the cases to investigate, but also permit the readiness checker to continue without an error.
## Changes
- Retry failed test S3 bucket creation with default config
- Log the failure without failing the check
## Testing
- How did you test your change?
