### PR TITLE
[preflight snowflake credentials] Make private key optional in check; don't write private key placeholder

### DIFF
--- a/serverless/panther-preflight-tools/connected-snowflake-credential-bootstrap/src/app.py
+++ b/serverless/panther-preflight-tools/connected-snowflake-credential-bootstrap/src/app.py
@@ -82,7 +82,6 @@ class PantherSnowflakeCredential:
                 "host": self.host,
                 "port": self.port,
                 "user": self.user,
-                "privateKey1": self.privateKey1,
                 "password": self.password,
             }
         )
@@ -97,7 +96,7 @@ class PantherSnowflakeCredential:
         if self.password == PASSWORD_PLACEHOLDER and self.privateKey1 == PRIVATE_KEY_PLACEHOLDER:
             raise ValueError("The secret must contain either a password or a private key, but not both.")
 
-        if self.privateKey1 != PRIVATE_KEY_PLACEHOLDER:
+        if self.privateKey1 && self.privateKey1 != PRIVATE_KEY_PLACEHOLDER:
             self._test_keypair()
         else:
             self._test_password()
@@ -145,8 +144,8 @@ def credentials_from_secret(client: boto3.Session) -> PantherSnowflakeCredential
         host=secret["host"],
         port=secret["port"],
         user=secret["user"],
-        privateKey1=secret["privateKey1"],
-        password=secret["password"],
+        privateKey1=secret.get("privateKey1"),
+        password=secret.get("password"),
     )
 
 


### PR DESCRIPTION
## Background

This tool will be replaced by a more comprehensive setup tool, but in the meantime, the private key setup is tripping up lots of initial account setups. We should continue using the password in the meantime before that tool rolls out.

## Changes

- Don't write private key into the placeholders of the account secret (the panther-enterprise code will always try to use a private key if the field exists, then fail when it's malformed)
- Handle a missing (optional) private key when run in validate/test mode

